### PR TITLE
Improvements for the bool_array_to_start_end_array function

### DIFF
--- a/gaitmap/utils/array_handling.py
+++ b/gaitmap/utils/array_handling.py
@@ -124,11 +124,10 @@ def bool_array_to_start_end_array(bool_array: np.ndarray) -> np.ndarray:
     array([1, 1])
 
     """
-    # check if input is a Series. For a Series, start and end will just be the first and last index
-    if isinstance(bool_array, pd.Series):
+    # check if input is a numpy array. E.g. for a Series, start and end will just be the first and last index.
+    if not isinstance(bool_array, np.ndarray):
         raise TypeError(
-            "Input must be boolean array! You provided a pandas Series."
-            "You can convert it to a numpy array with .values"
+            f"Input must be a numpy array!"
         )
 
     # check if input is actually a boolean array

--- a/gaitmap/utils/array_handling.py
+++ b/gaitmap/utils/array_handling.py
@@ -3,7 +3,6 @@ from typing import Iterable, Iterator, List, Optional, Tuple, Union
 
 import numba.typed
 import numpy as np
-import pandas as pd
 from numba import njit
 from scipy.interpolate import interp1d
 from scipy.signal import find_peaks
@@ -126,9 +125,7 @@ def bool_array_to_start_end_array(bool_array: np.ndarray) -> np.ndarray:
     """
     # check if input is a numpy array. E.g. for a Series, start and end will just be the first and last index.
     if not isinstance(bool_array, np.ndarray):
-        raise TypeError(
-            "Input must be a numpy array!"
-        )
+        raise TypeError("Input must be a numpy array!")
 
     # check if input is actually a boolean array
     if not np.array_equal(bool_array, bool_array.astype(bool)):

--- a/gaitmap/utils/array_handling.py
+++ b/gaitmap/utils/array_handling.py
@@ -101,7 +101,8 @@ def sliding_window_view(arr: np.ndarray, window_length: int, overlap: int, nan_p
 def bool_array_to_start_end_array(bool_array: np.ndarray) -> np.ndarray:
     """Find regions in bool array and convert those to start-end indices.
 
-    The end index is inclusiv!
+    The end index is the first element after the True-region,
+    so you can use it for upper-bound exclusive slicing etc.
 
     Parameters
     ----------

--- a/gaitmap/utils/array_handling.py
+++ b/gaitmap/utils/array_handling.py
@@ -3,6 +3,7 @@ from typing import Iterable, Iterator, List, Optional, Tuple, Union
 
 import numba.typed
 import numpy as np
+import pandas as pd
 from numba import njit
 from scipy.interpolate import interp1d
 from scipy.signal import find_peaks
@@ -122,6 +123,13 @@ def bool_array_to_start_end_array(bool_array: np.ndarray) -> np.ndarray:
     array([1, 1])
 
     """
+    # check if input is a Series. For a Series, start and end will just be the first and last index
+    if isinstance(bool_array, pd.Series):
+        raise TypeError(
+            "Input must be boolean array! You provided a pandas Series."
+            "You can convert it to a numpy array with .values"
+        )
+
     # check if input is actually a boolean array
     if not np.array_equal(bool_array, bool_array.astype(bool)):
         raise ValueError("Input must be boolean array!")

--- a/gaitmap/utils/array_handling.py
+++ b/gaitmap/utils/array_handling.py
@@ -127,7 +127,7 @@ def bool_array_to_start_end_array(bool_array: np.ndarray) -> np.ndarray:
     # check if input is a numpy array. E.g. for a Series, start and end will just be the first and last index.
     if not isinstance(bool_array, np.ndarray):
         raise TypeError(
-            f"Input must be a numpy array!"
+            "Input must be a numpy array!"
         )
 
     # check if input is actually a boolean array


### PR DESCRIPTION
The function does now check if a Series is supplied instead of a numpy array and throws an Error. It used to return just the first and last index for a Series.

Also, I think the statement "The end index is *inclusive*!" from the docs was misleading, because it sounds like the end index is pointing to the last element that is *included* in the True-region, but it points to the first False element.