### PR TITLE
Fix empty array handling when merging intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ For more information see the
 [Github Releases Page](https://github.com/mad-lab-fau/gaitmap/releases) of this 
 project.
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a bug that when using `merge_interval` with empty input of shape (0, 2), the output was not empty.
+  (https://github.com/mad-lab-fau/gaitmap/pull/61)
+
 ## [2.3.0] - 2023-08-03
 
 ### Changed

--- a/gaitmap/utils/array_handling.py
+++ b/gaitmap/utils/array_handling.py
@@ -397,6 +397,9 @@ def merge_intervals(input_array: np.ndarray, gap_size: int = 0) -> np.ndarray:
            [18, 20]])
 
     """
+    if input_array.shape[0] == 0:
+        return input_array
+
     return np.array(_solve_overlap(np.sort(input_array, axis=0, kind="stable"), gap_size))
 
 

--- a/tests/test_utils/test_array_handling.py
+++ b/tests/test_utils/test_array_handling.py
@@ -472,6 +472,7 @@ class TestMergeIntervals:
                 np.array([[-2, 5]]),
                 1,
             ),
+            (np.empty(shape=(0, 2)), np.empty(shape=(0, 2)), 0),
             (
                 np.array([[]]),
                 np.array([[]]),


### PR DESCRIPTION
Calling `merge_intervals(np.ndarray(shape=(0, 2)))` returned a numpy array with shape (1, 2)  filled with random numbers.

These changes fix that by just returning the original array in case it is empty.