### PR TITLE
Update _forward_backwards_integration.py

### DIFF
--- a/gaitmap/trajectory_reconstruction/position_methods/_forward_backwards_integration.py
+++ b/gaitmap/trajectory_reconstruction/position_methods/_forward_backwards_integration.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 from tpcp import cf
 from typing_extensions import Self
 

--- a/gaitmap/trajectory_reconstruction/position_methods/_forward_backwards_integration.py
+++ b/gaitmap/trajectory_reconstruction/position_methods/_forward_backwards_integration.py
@@ -149,11 +149,11 @@ class ForwardBackwardIntegration(BasePositionMethod):
         # Add an implicit 0 to the beginning of the acc data
         padded_acc = np.pad(acc_data, pad_width=((1, 0), (0, 0)), constant_values=0)
         velocity = self._forward_backward_integration(padded_acc)
-        position_xy = cumtrapz(velocity[:, :2], axis=0, initial=0) / self.sampling_rate_hz
+        position_xy = cumulative_trapezoid(velocity[:, :2], axis=0, initial=0) / self.sampling_rate_hz
         if self.level_assumption is True:
             position_z = self._forward_backward_integration(velocity[:, [2]])
         else:
-            position_z = cumtrapz(velocity[:, [2]], axis=0, initial=0) / self.sampling_rate_hz
+            position_z = cumulative_trapezoid(velocity[:, [2]], axis=0, initial=0) / self.sampling_rate_hz
         position = np.hstack((position_xy, position_z))
 
         self.velocity_ = pd.DataFrame(velocity, columns=GF_VEL)
@@ -171,9 +171,9 @@ class ForwardBackwardIntegration(BasePositionMethod):
 
     def _forward_backward_integration(self, data: np.ndarray) -> np.ndarray:
         # TODO: different steepness and turning point for velocity and position?
-        integral_forward = cumtrapz(data, axis=0, initial=0) / self.sampling_rate_hz
+        integral_forward = cumulative_trapezoid(data, axis=0, initial=0) / self.sampling_rate_hz
         # for backward integration, we flip the signal and inverse the time by using a negative sampling rate.
-        integral_backward = cumtrapz(data[::-1], axis=0, initial=0) / -self.sampling_rate_hz
+        integral_backward = cumulative_trapezoid(data[::-1], axis=0, initial=0) / -self.sampling_rate_hz
         weights = self._sigmoid_weight_function(integral_forward.shape[0])
         combined = (integral_forward.T * (1 - weights) + integral_backward[::-1].T * weights).T
         return combined

--- a/gaitmap_mad/gaitmap_mad/trajectory_reconstruction/position_methods/_piece_wise_linear_dedrifted_integration.py
+++ b/gaitmap_mad/gaitmap_mad/trajectory_reconstruction/position_methods/_piece_wise_linear_dedrifted_integration.py
@@ -5,7 +5,7 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 from numpy.polynomial import polynomial
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 from scipy.interpolate import interp1d
 from tpcp import cf
 from typing_extensions import Self

--- a/gaitmap_mad/gaitmap_mad/trajectory_reconstruction/position_methods/_piece_wise_linear_dedrifted_integration.py
+++ b/gaitmap_mad/gaitmap_mad/trajectory_reconstruction/position_methods/_piece_wise_linear_dedrifted_integration.py
@@ -181,11 +181,11 @@ class PieceWiseLinearDedriftedIntegration(BasePositionMethod):
         # shift zupts to fit to the padded acc data!
         zupts_padded = self.zupts_ + 1
 
-        velocity = cumtrapz(acc_data_padded, axis=0, initial=0) / self.sampling_rate_hz
+        velocity = cumulative_trapezoid(acc_data_padded, axis=0, initial=0) / self.sampling_rate_hz
         drift_model = self._estimate_piece_wise_linear_drift_model(velocity, zupts_padded)
         velocity -= drift_model
 
-        position = cumtrapz(velocity, axis=0, initial=0) / self.sampling_rate_hz
+        position = cumulative_trapezoid(velocity, axis=0, initial=0) / self.sampling_rate_hz
 
         if self.level_assumption is True:
             position[:, -1] -= self._estimate_piece_wise_linear_drift_model(position[:, -1], zupts_padded)


### PR DESCRIPTION
function scipy.integrate.cumtrapz deprecated in Version SciPy 1.6.0.  Re-named: scipy.integrate.cumulative_trapezoid